### PR TITLE
Get an almost-executable-query

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -181,10 +181,21 @@ Builder.prototype.build = function(params) {
 
 	this._query = this.buildTemplate('query', {queryBody: params}) + ';';
 
+        var myQuery = this._query;
+        var arrParams = myQuery.match(/([$][a-z]+[0-9]+)/g);
+        var arrValues = _.isArray(this._values) ? this._values : _(this._values).values();
+
+        for(var i=0;i<arrParams.length;i++){
+            myQuery = myQuery.replace(arrParams[i],"$" + arrValues[i] + "$");
+        }
+
+        var cleanQuery = myQuery.replace(/\"/g,"");
+    
 	if (this.options.separatedValues) {
 		return {
 			query: this._query,
 			values: this._values,
+			replaceDolarQuery: cleanQuery,
 			prefixValues: function() {
 				var values = {};
 				_(this.getValuesObject()).each(function(value, name) {


### PR DESCRIPTION
You shoul have almost an executable query, for example:

sql.query
// insert into users (name, lastname, age, gender) values ($p1, $p2, 24, $p3);

sql.values
// { p1: 'John', p2: 'Snow', p3: 'male' }

sql.replaceDolarQuery
// insert into users (name, lastname, age, gender) values ($John$, $Snow$, 24, $male$);

And then you just have to do a simple replace when you send that query to be executed. 

Something like this:

console.log(sql.replaceDolarQuery.replace(/\$/g,"'"));
// insert into users (name, lastname, age, gender) values ('John', 'Snow', 24, 'male');