### PR TITLE
add ilike for postgresql

### DIFF
--- a/lib/dialects/postgresql/operators/comparison.js
+++ b/lib/dialects/postgresql/operators/comparison.js
@@ -39,4 +39,20 @@ module.exports = function(dialect) {
 			return buildComparisonCondition(field, '?&', value);
 		}
 	});
+
+	dialect.operators.comparison.add('$ilike', {
+		inversedOperator: '$nilike',
+		defaultFetchingOperator: '$value',
+		fn: function(field, value) {
+			return buildComparisonCondition(field, 'ilike', value);
+		}
+	});
+
+	dialect.operators.comparison.add('$nilike', {
+		inversedOperator: '$ilike',
+		defaultFetchingOperator: '$value',
+		fn: function(field, value) {
+			return buildComparisonCondition(field, 'not ilike', value);
+		}
+	});
 };

--- a/tests/6_postgresDialect.js
+++ b/tests/6_postgresDialect.js
@@ -94,5 +94,33 @@ describe('PostgreSQL dialect', function() {
 			);
 			expect(result.values).to.be.eql(['a', 'b']);
 		});
+
+		it('should be ok with `$ilike` conditional operator', function() {
+			var result = jsonSql.build({
+				table: 'test',
+				condition: {
+					params: {$ilike: 'hello%'}
+				}
+			});
+
+			expect(result.query).to.be.equal(
+				'select * from "test" where "params" ilike $1;'
+			);
+			expect(result.values).to.be.eql(['hello%']);
+		});
+
+		it('should be ok with `$nilike` conditional operator', function() {
+			var result = jsonSql.build({
+				table: 'test',
+				condition: {
+					params: {$nilike: 'hello%'}
+				}
+			});
+
+			expect(result.query).to.be.equal(
+				'select * from "test" where "params" not ilike $1;'
+			);
+			expect(result.values).to.be.eql(['hello%']);
+		});
 	});
 });


### PR DESCRIPTION
Added `ilike` (basically it's a case-insensitive `like`) comparison operator for PostgreSQL dialect. This operator is PostgreSQL-specific (http://www.postgresql.org/docs/9.4/static/functions-matching.html). 

Tests are included.

Добавил регистронезависимую версию оператора `like` — `ilike`, которая специфичная для PostgreSQL. Тесты тоже есть. 