### PR TITLE
Fix typo at docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -74,7 +74,7 @@ Set options of json-sql builder instance.
 
 ### setDialect(name)
 
-Set active dialect, name can has value `'base'`, `'mssql'`, `'mysql'`, `'postrgresql'` or `'sqlite'`.
+Set active dialect, name can has value `'base'`, `'mssql'`, `'mysql'`, `'postgresql'` or `'sqlite'`.
 
 ---
 


### PR DESCRIPTION
Fix typo in PostgreSQL dialect name in `setDialect()` description.