### PR TITLE
add usePlaceholderId option

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -69,7 +69,7 @@ Set options of json-sql builder instance.
 | `valuesPrefix` | `'$'` | Prefix for values placeholders<br>Option is used if `namedValues = true`. |
 | `dialect` | `'base'` | Active dialect. See setDialect for dialects list. |
 | `wrappedIdentifiers` | `true` | If `true` - wrap all identifiers with dialect wrapper (name -> "name"). |
-| `usePlaceholderId` | `true` | If `true` - uses auto-generated id for values placeholders after the value prefix |
+| `indexedValues` | `true` | If `true` - uses auto-generated id for values placeholders after the value prefix |
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,6 +69,7 @@ Set options of json-sql builder instance.
 | `valuesPrefix` | `'$'` | Prefix for values placeholders<br>Option is used if `namedValues = true`. |
 | `dialect` | `'base'` | Active dialect. See setDialect for dialects list. |
 | `wrappedIdentifiers` | `true` | If `true` - wrap all identifiers with dialect wrapper (name -> "name"). |
+| `usePlaceholderId` | `true` | If `true` - uses auto-generated id for values placeholders after the value prefix |
 
 ---
 

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -26,8 +26,14 @@ Builder.prototype._reset = function() {
 	this._query = '';
 };
 
-Builder.prototype._getPlaceholder = function() {
-	return (this.options.namedValues ? 'p' : '') + (this.options.usePlaceholderId ? (this._placeholderId++) : '');
+Builder.prototype._getPlaceholder = function () {
+  if (this.options.namedValues && !this.options.indexedValues) {
+    throw new Error('Use of options "indexedValues: false" is ' +
+      'not allowed together with "namedValues: true"');
+  }
+  var placeholder = this.options.namedValues ? 'p' : '';
+  var index = this.options.indexedValues ? (this._placeholderId++) : '';
+	return placeholder + index;
 };
 
 Builder.prototype._wrapPlaceholder = function(name) {
@@ -65,7 +71,7 @@ Builder.prototype.configure = function(options) {
 		valuesPrefix: '$',
 		dialect: 'base',
 		wrappedIdentifiers: true,
-		usePlaceholderId: true
+		indexedValues: true
 	});
 
 	this.setDialect(this.options.dialect);

--- a/tests/0_base.js
+++ b/tests/0_base.js
@@ -205,7 +205,7 @@ describe('Builder', function() {
 
 		expect(result.query).to.be.equal('select * from "users" where "name" = $1;');
 		expect(result.values).to.be.eql(['John']);
-	});
+  });
 
 	it('should use prefix `@` for values with option `valuesPrefix` = @', function() {
 		jsonSql.configure({
@@ -219,7 +219,7 @@ describe('Builder', function() {
 
 		expect(result.query).to.be.equal('select * from "users" where "name" = @p1;');
 		expect(result.values).to.be.eql({p1: 'John'});
-	});
+  });
 
 	it('should return prefixed values with method `prefixValues`', function() {
 		var result = jsonSql.build({
@@ -230,7 +230,7 @@ describe('Builder', function() {
 		expect(result.query).to.be.equal('select * from "users" where "name" = @p1;');
 		expect(result.values).to.be.eql({p1: 'John'});
 		expect(result.prefixValues()).to.be.eql({'@p1': 'John'});
-	});
+  });
 
 	it('should return array values with method `getValuesArray`', function() {
 		var result = jsonSql.build({
@@ -260,6 +260,36 @@ describe('Builder', function() {
 		expect(result.values).to.be.eql(['John']);
 		expect(result.prefixValues()).to.be.eql({'$1': 'John'});
 		expect(result.getValuesObject()).to.be.eql({1: 'John'});
+  });
+
+  it('should throw if `indexedValues = false` and `namedValues = true`', function() {
+    jsonSql.configure({
+      namedValues: true,
+			indexedValues: false
+		});
+
+    expect(function() {
+			jsonSql.build({
+        table: 'users',
+        condition: {name: 'John'}
+      });
+    }).to.throw('Use of options "indexedValues: false" is ' +
+      'not allowed together with "namedValues: true"');
+	});
+  
+  it('should not use index for values with option `indexedValues` = false', function() {
+    jsonSql.configure({
+      namedValues: false,
+			indexedValues: false
+		});
+
+		var result = jsonSql.build({
+			table: 'users',
+			condition: {name: 'John'}
+		});
+
+		expect(result.query).to.be.equal('select * from "users" where "name" = $;');
+		expect(result.values).to.be.eql(['John']);
 	});
 
 	it('should create query without values with option `separatedValues` = false', function() {


### PR DESCRIPTION
mysqljs (others might too) requires query values to be escaped [via a question mark](https://github.com/mysqljs/mysql#performing-queries).
`usePlaceholderId` option is added In order to facilitate this behaviour
```javascript
let jsonSql = require('json-sql')({
  dialect: 'mysql',
  namedValues: false,
  valuesPrefix: '?',
  usePlaceholderId: false
});
```