### PR TITLE
OFFSET/FETCH for MSSQL 2012 and later

### DIFF
--- a/lib/dialects/base/blocks.js
+++ b/lib/dialects/base/blocks.js
@@ -300,15 +300,15 @@ module.exports = function(dialect) {
 		var sort = params.sort;
 		var result = '';
 
-		if (_.isString(sort)) sort = [sort];
+		if (_.isString(sort) || _.isNumber(sort)) sort = [sort];
 
 		if (_.isArray(sort)) {
 			result = _(sort).map(function(sortField) {
-				return dialect._wrapIdentifier(sortField);
+				return _.isNumber(sortField) ? sortField : dialect._wrapIdentifier(sortField);
 			}).join(', ');
 		} else if (_.isObject(sort)) {
 			result = _(sort).map(function(direction, field) {
-				return dialect._wrapIdentifier(field) + ' ' + (direction > 0 ? 'asc' : 'desc');
+				return (_.isNumber(field) ? field : dialect._wrapIdentifier(field)) + ' ' + (direction > 0 ? 'asc' : 'desc');
 			}).join(', ');
 		}
 

--- a/lib/dialects/mssql/blocks.js
+++ b/lib/dialects/mssql/blocks.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var	_ = require('underscore');
+
+module.exports = function(dialect) {
+
+    dialect.blocks.add('limit', function(params) {
+
+        if (_.isUndefined(params.offset)) {
+			return dialect.buildBlock('offset', { offset: 0, limit: params.limit }) + ' ';
+		}
+
+        return '';
+	});
+
+	dialect.blocks.add('offset', function(params) {
+        let sort = '';
+        if (_.isUndefined(params.sort)) {
+            sort = dialect.buildBlock('sort', { sort: 1 }) + ' ';
+        }
+
+        if (_.isUndefined(params.limit)) {
+            return sort+'OFFSET ' + dialect.builder._pushValue(params.offset) + ' ROWS';
+        }
+		return sort+'OFFSET ' + dialect.builder._pushValue(params.offset) + ' ROWS FETCH NEXT ' + dialect.builder._pushValue(params.limit) + ' ROWS ONLY';
+	});
+};

--- a/lib/dialects/mssql/index.js
+++ b/lib/dialects/mssql/index.js
@@ -3,9 +3,13 @@
 var BaseDialect = require('../base');
 var _ = require('underscore');
 var util = require('util');
+var blocksInit = require('./blocks');
 
 var Dialect = module.exports = function(builder) {
 	BaseDialect.call(this, builder);
+
+	// init blocks
+	blocksInit(this);
 };
 
 util.inherits(Dialect, BaseDialect);


### PR DESCRIPTION
This will replace the limit/offset style with MSSQL 2012 OFFSET and Fetch functions.
Since OFFSET and Fetch needs an ORDER BY Statement, this patch will allow to order by numbers (ORDER BY 1) .