### PR TITLE
add MSSQL support (requested changes)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,7 +18,7 @@ gulp.task('coverage', function(callback) {
 		.pipe(istanbul())
 		.pipe(istanbul.hookRequire())
 		.on('finish', function() {
-			gulp.src(['./tests/*.js'], {read: false})
+			gulp.src(['./tests/**/*.js'], {read: false})
 				.pipe(mocha({
 					reporter: 'spec',
 					bail: true

--- a/lib/dialects/base/blocks.js
+++ b/lib/dialects/base/blocks.js
@@ -333,10 +333,11 @@ module.exports = function(dialect) {
 
 	dialect.blocks.add('insert:values', function(params) {
 		var values = params.values;
+		var fields = params.fields;
 
 		if (!_.isArray(values)) values = [values];
 
-		var fields = params.fields || _(values)
+		fields = fields || _(values)
 			.chain()
 			.map(function(row) {
 				return _(row).keys();
@@ -345,13 +346,15 @@ module.exports = function(dialect) {
 			.uniq()
 			.value();
 
+		values = _(values).map(function(row) {
+			return _(fields).map(function(field) {
+				return dialect.buildBlock('value', {value: row[field]});
+			});
+		});
+
 		return dialect.buildTemplate('insertValues', {
-			fields: fields,
-			values: _(values).map(function(row) {
-				return _(fields).map(function(field) {
-					return dialect.buildBlock('value', {value: row[field]});
-				});
-			})
+			values: values,
+			fields: fields
 		});
 	});
 

--- a/lib/dialects/base/index.js
+++ b/lib/dialects/base/index.js
@@ -347,7 +347,8 @@ Dialect.prototype.buildTemplate = function(type, params) {
 			return '';
 		} else {
 			if (self.blocks.has(type + ':' + block)) block = type + ':' + block;
-			return self.buildBlock(block, params) + space;
+			var result = self.buildBlock(block, params);
+			return result === '' ? result : result + space;
 		}
 	}).trim();
 };

--- a/lib/dialects/mssql/blocks.js
+++ b/lib/dialects/mssql/blocks.js
@@ -19,41 +19,41 @@ module.exports = function(dialect) {
   });
 
   dialect.blocks.set('returning', function(params) {
-		var result = dialect.buildBlock('fields', {fields: params.returning});
+    var result = dialect.buildBlock('fields', {fields: params.returning});
 
-		if (result) result = 'output ' + result;
+    if (result) result = 'output ' + result;
 
-		return result;
-	});
+    return result;
+  });
 
   dialect.blocks.set('insert:values', function(params) {
-		var values = params.values;
+    var values = params.values;
 
-		if (!_.isArray(values)) values = [values];
+    if (!_.isArray(values)) values = [values];
 
-		var fields = params.fields || _(values)
-			.chain()
-			.map(function(row) {
-				return _(row).keys();
-			})
-			.flatten()
-			.uniq()
-			.value();
+    var fields = params.fields || _(values)
+     .chain()
+     .map(function(row) {
+      return _(row).keys();
+    })
+     .flatten()
+     .uniq()
+     .value();
 
-		return dialect.buildTemplate('insertValues', {
-			fields: fields,
+    return dialect.buildTemplate('insertValues', {
+      fields: fields,
       returning: params.returning || undefined,
-			values: _(values).map(function(row) {
-				return _(fields).map(function(field) {
-					return dialect.buildBlock('value', {value: row[field]});
-				});
-			})
-		});
-	});
+      values: _(values).map(function(row) {
+        return _(fields).map(function(field) {
+          return dialect.buildBlock('value', {value: row[field]});
+        });
+      })
+    });
+  });
 
   dialect.blocks.add('insertValues:values', function(params) {
-		return _(params.values).map(function(row) {
-			return '(' + row.join(', ') + ')';
-		}).join(', ');
-	});
+    return _(params.values).map(function(row) {
+      return '(' + row.join(', ') + ')';
+    }).join(', ');
+  });
 };

--- a/lib/dialects/mssql/blocks.js
+++ b/lib/dialects/mssql/blocks.js
@@ -3,57 +3,57 @@
 var _ = require('underscore');
 
 module.exports = function(dialect) {
-  dialect.blocks.set('limit', function(params) {
-    return (!isNaN(params.offset)) ? '' : 'top(' + dialect.builder._pushValue(params.limit) + ')';
-  });
+	dialect.blocks.set('limit', function(params) {
+		return (!isNaN(params.offset)) ? '' : 'top(' + dialect.builder._pushValue(params.limit) + ')';
+	});
 
-  dialect.blocks.set('offset', function(params) {
-    var pre = (!params.sort) ? 'order by 1 ' : '';
-    if (params.limit) {
-      var str = pre + 'offset ' + dialect.builder._pushValue(params.offset);
-      str += ' rows fetch next ' + dialect.builder._pushValue(params.limit) + ' rows only';
-      return str;
-    }else {
-      return pre + 'OFFSET ' + dialect.builder._pushValue(params.offset) + ' rows';
-    }
-  });
+	dialect.blocks.set('offset', function(params) {
+		var pre = (!params.sort) ? 'order by 1 ' : '';
+		if (params.limit) {
+			var str = pre + 'offset ' + dialect.builder._pushValue(params.offset);
+			str += ' rows fetch next ' + dialect.builder._pushValue(params.limit) + ' rows only';
+			return str;
+		}else {
+			return pre + 'OFFSET ' + dialect.builder._pushValue(params.offset) + ' rows';
+		}
+	});
 
-  dialect.blocks.set('returning', function(params) {
-    var result = dialect.buildBlock('fields', {fields: params.returning});
+	dialect.blocks.set('returning', function(params) {
+		var result = dialect.buildBlock('fields', {fields: params.returning});
 
-    if (result) result = 'output ' + result;
+		if (result) result = 'output ' + result;
 
-    return result;
-  });
+		return result;
+	});
 
-  dialect.blocks.set('insert:values', function(params) {
-    var values = params.values;
+	dialect.blocks.set('insert:values', function(params) {
+		var values = params.values;
 
-    if (!_.isArray(values)) values = [values];
+		if (!_.isArray(values)) values = [values];
 
-    var fields = params.fields || _(values)
-     .chain()
-     .map(function(row) {
-      return _(row).keys();
-    })
-     .flatten()
-     .uniq()
-     .value();
+		var fields = params.fields || _(values)
+		 .chain()
+		 .map(function(row) {
+			return _(row).keys();
+		})
+		 .flatten()
+		 .uniq()
+		 .value();
 
-    return dialect.buildTemplate('insertValues', {
-      fields: fields,
-      returning: params.returning || undefined,
-      values: _(values).map(function(row) {
-        return _(fields).map(function(field) {
-          return dialect.buildBlock('value', {value: row[field]});
-        });
-      })
-    });
-  });
+		return dialect.buildTemplate('insertValues', {
+			fields: fields,
+			returning: params.returning || undefined,
+			values: _(values).map(function(row) {
+				return _(fields).map(function(field) {
+					return dialect.buildBlock('value', {value: row[field]});
+				});
+			})
+		});
+	});
 
-  dialect.blocks.add('insertValues:values', function(params) {
-    return _(params.values).map(function(row) {
-      return '(' + row.join(', ') + ')';
-    }).join(', ');
-  });
+	dialect.blocks.add('insertValues:values', function(params) {
+		return _(params.values).map(function(row) {
+			return '(' + row.join(', ') + ')';
+		}).join(', ');
+	});
 };

--- a/lib/dialects/mssql/blocks.js
+++ b/lib/dialects/mssql/blocks.js
@@ -1,0 +1,59 @@
+'use strict';
+
+var _ = require('underscore');
+
+module.exports = function(dialect) {
+  dialect.blocks.set('limit', function(params) {
+    return (!isNaN(params.offset)) ? '' : 'top(' + dialect.builder._pushValue(params.limit) + ')';
+  });
+
+  dialect.blocks.set('offset', function(params) {
+    var pre = (!params.sort) ? 'order by 1 ' : '';
+    if (params.limit) {
+      var str = pre + 'offset ' + dialect.builder._pushValue(params.offset);
+      str += ' rows fetch next ' + dialect.builder._pushValue(params.limit) + ' rows only';
+      return str;
+    }else {
+      return pre + 'OFFSET ' + dialect.builder._pushValue(params.offset) + ' rows';
+    }
+  });
+
+  dialect.blocks.set('returning', function(params) {
+		var result = dialect.buildBlock('fields', {fields: params.returning});
+
+		if (result) result = 'output ' + result;
+
+		return result;
+	});
+
+  dialect.blocks.set('insert:values', function(params) {
+		var values = params.values;
+
+		if (!_.isArray(values)) values = [values];
+
+		var fields = params.fields || _(values)
+			.chain()
+			.map(function(row) {
+				return _(row).keys();
+			})
+			.flatten()
+			.uniq()
+			.value();
+
+		return dialect.buildTemplate('insertValues', {
+			fields: fields,
+      returning: params.returning || undefined,
+			values: _(values).map(function(row) {
+				return _(fields).map(function(field) {
+					return dialect.buildBlock('value', {value: row[field]});
+				});
+			})
+		});
+	});
+
+  dialect.blocks.add('insertValues:values', function(params) {
+		return _(params.values).map(function(row) {
+			return '(' + row.join(', ') + ')';
+		}).join(', ');
+	});
+};

--- a/lib/dialects/mssql/blocks.js
+++ b/lib/dialects/mssql/blocks.js
@@ -9,19 +9,8 @@ module.exports = function(dialect) {
 		var value = params.value;
 
 		var result;
-		if (_.isUndefined(value) || _.isNull(value)) {
-			result = 'null';
-		} else if (_.isBoolean(value)) {
+		if (_.isBoolean(value)) {
 			result = String(Number(value));
-		} else if (_.isNumber(value)) {
-			result = String(value);
-		} else if (_.isString(value) || _.isDate(value)) {
-			if (dialect.builder.options.separatedValues) {
-				result = dialect.builder._pushValue(value);
-			} else {
-				if (_.isDate(value)) value = value.toISOString();
-				result =  '\'' + value + '\'';
-			}
 		} else {
 			result = parentValueBlock(params);
 		}

--- a/lib/dialects/mssql/blocks.js
+++ b/lib/dialects/mssql/blocks.js
@@ -3,19 +3,52 @@
 var _ = require('underscore');
 
 module.exports = function(dialect) {
+	var parentValueBlock = dialect.blocks.get('value');
+
+	dialect.blocks.set('value', function(params) {
+		var value = params.value;
+
+		var result;
+		if (_.isUndefined(value) || _.isNull(value)) {
+			result = 'null';
+		} else if (_.isBoolean(value)) {
+			result = String(Number(value));
+		} else if (_.isNumber(value)) {
+			result = String(value);
+		} else if (_.isString(value) || _.isDate(value)) {
+			if (dialect.builder.options.separatedValues) {
+				result = dialect.builder._pushValue(value);
+			} else {
+				if (_.isDate(value)) value = value.toISOString();
+				result =  '\'' + value + '\'';
+			}
+		} else {
+			result = parentValueBlock(params);
+		}
+
+		return result;
+	});
+
 	dialect.blocks.set('limit', function(params) {
-		return (!isNaN(params.offset)) ? '' : 'top(' + dialect.builder._pushValue(params.limit) + ')';
+		var result = '';
+		if (_.isUndefined(params.offset)) {
+			result = 'top(' + dialect.builder._pushValue(params.limit) + ')';
+		}
+		return result;
 	});
 
 	dialect.blocks.set('offset', function(params) {
-		var pre = (!params.sort) ? 'order by 1 ' : '';
+		var prefix = (!params.sort) ? 'order by 1 ' : '';
+		var offset = 'offset ' + dialect.builder._pushValue(params.offset) + ' ';
+		var limit = '';
+		var suffix = 'rows';
+
 		if (params.limit) {
-			var str = pre + 'offset ' + dialect.builder._pushValue(params.offset);
-			str += ' rows fetch next ' + dialect.builder._pushValue(params.limit) + ' rows only';
-			return str;
-		}else {
-			return pre + 'OFFSET ' + dialect.builder._pushValue(params.offset) + ' rows';
+			limit = 'rows fetch next ' + dialect.builder._pushValue(params.limit) + ' ';
+			suffix = 'rows only';
 		}
+
+		return prefix + offset + limit + suffix;
 	});
 
 	dialect.blocks.set('returning', function(params) {
@@ -28,32 +61,30 @@ module.exports = function(dialect) {
 
 	dialect.blocks.set('insert:values', function(params) {
 		var values = params.values;
+		var fields = params.fields;
+		var returning = params.returning;
 
 		if (!_.isArray(values)) values = [values];
 
-		var fields = params.fields || _(values)
-		 .chain()
-		 .map(function(row) {
-			return _(row).keys();
-		})
-		 .flatten()
-		 .uniq()
-		 .value();
+		fields = fields || _(values)
+			.chain()
+			.map(function(row) {
+				return _(row).keys();
+			})
+			.flatten()
+			.uniq()
+			.value();
+
+		values = _(values).map(function(row) {
+			return _(fields).map(function(field) {
+				return dialect.buildBlock('value', {value: row[field]});
+			});
+		});
 
 		return dialect.buildTemplate('insertValues', {
+			values: values,
 			fields: fields,
-			returning: params.returning || undefined,
-			values: _(values).map(function(row) {
-				return _(fields).map(function(field) {
-					return dialect.buildBlock('value', {value: row[field]});
-				});
-			})
+			returning: returning
 		});
-	});
-
-	dialect.blocks.add('insertValues:values', function(params) {
-		return _(params.values).map(function(row) {
-			return '(' + row.join(', ') + ')';
-		}).join(', ');
 	});
 };

--- a/lib/dialects/mssql/index.js
+++ b/lib/dialects/mssql/index.js
@@ -10,7 +10,7 @@ var Dialect = module.exports = function(builder) {
 	BaseDialect.call(this, builder);
 
 	this.blocks.set('limit', function(params) {
-		return (params.offset) ? '' : 'TOP(' + builder._pushValue(params.limit) + ')';
+		return (!isNaN(params.offset)) ? '' : 'TOP(' + builder._pushValue(params.limit) + ')';
 	});
 
 	this.blocks.set('offset', function(params) {

--- a/lib/dialects/mssql/index.js
+++ b/lib/dialects/mssql/index.js
@@ -6,22 +6,25 @@ var util = require('util');
 var templateChecks = require('../../utils/templateChecks');
 
 var Dialect = module.exports = function(builder) {
+	builder.options.valuesPrefix = '@';
 	BaseDialect.call(this, builder);
 
-  this.blocks.set('limit', function(params) {
+	this.blocks.set('limit', function(params) {
 		return (params.offset) ? '' : 'TOP(' + builder._pushValue(params.limit) + ')';
 	});
 
-  this.blocks.set('offset', function(params) {
-    var pre = (!params.sort) ? 'ORDER BY 1 ' : '';
-    if (params.limit) {
-      return pre + 'OFFSET ' + params.offset + ' ROWS FETCH NEXT ' + params.limit + ' ROWS ONLY';
-    }else {
-      return pre + 'OFFSET ' + params.offset + ' ROWS';
-    }
+	this.blocks.set('offset', function(params) {
+		var pre = (!params.sort) ? 'ORDER BY 1 ' : '';
+		if (params.limit) {
+			var str = pre + 'OFFSET ' + builder._pushValue(params.offset);
+			str += ' ROWS FETCH NEXT ' + builder._pushValue(params.limit) + ' ROWS ONLY';
+			return str;
+		}else {
+			return pre + 'OFFSET ' + builder._pushValue(params.offset) + ' ROWS';
+		}
 	});
 
-  this.templates.set('select', {
+	this.templates.set('select', {
 		pattern: '{with} {withRecursive} select {limit} {distinct} {fields} ' +
 			'from {from} {table} {query} {select} {expression} {alias} ' +
 			'{join} {condition} {group} {having} {sort} {offset}',
@@ -58,7 +61,7 @@ var Dialect = module.exports = function(builder) {
 
 			templateChecks.propType(type, params, 'sort', ['string', 'array', 'object']);
 
-      templateChecks.propType(type, params, 'offset', ['number', 'string']);
+			templateChecks.propType(type, params, 'offset', ['number', 'string']);
 			templateChecks.propType(type, params, 'limit', ['number', 'string']);
 		}
 	});

--- a/lib/dialects/mssql/index.js
+++ b/lib/dialects/mssql/index.js
@@ -5,45 +5,44 @@ var _ = require('underscore');
 var util = require('util');
 var templatesInit = require('./templates');
 var blocksInit = require('./blocks');
-var templateChecks = require('../../utils/templateChecks');
 
 var Dialect = module.exports = function(builder) {
 
-  builder._pushValue = function(value) {
-    if (_.isUndefined(value) || _.isNull(value)) {
-      return 'null';
-    } else if (_.isBoolean(value)) {
-      return String(Number(value));
-    } else if (_.isNumber(value)) {
-      return String(value);
-    } else if (_.isString(value) || _.isDate(value)) {
-      if (this.options.separatedValues) {
-        var placeholder = this._getPlaceholder();
+	builder._pushValue = function(value) {
+		if (_.isUndefined(value) || _.isNull(value)) {
+			return 'null';
+		} else if (_.isBoolean(value)) {
+			return String(Number(value));
+		} else if (_.isNumber(value)) {
+			return String(value);
+		} else if (_.isString(value) || _.isDate(value)) {
+			if (this.options.separatedValues) {
+				var placeholder = this._getPlaceholder();
 
-        if (this.options.namedValues) {
-          this._values[placeholder] = value;
-        } else {
-          this._values.push(value);
-        }
+				if (this.options.namedValues) {
+					this._values[placeholder] = value;
+				} else {
+					this._values.push(value);
+				}
 
-        return this._wrapPlaceholder(placeholder);
-      } else {
-        if (_.isDate(value)) value = value.toISOString();
+				return this._wrapPlaceholder(placeholder);
+			} else {
+				if (_.isDate(value)) value = value.toISOString();
 
-        return '\'' + value + '\'';
-      }
-    } else {
-      throw new Error('Wrong value type "' + (typeof value) + '"');
-    }
-  };
+				return '\'' + value + '\'';
+			}
+		} else {
+			throw new Error('Wrong value type "' + (typeof value) + '"');
+		}
+	};
 
-  BaseDialect.call(this, builder);
+	BaseDialect.call(this, builder);
 
-  // init templates
-  templatesInit(this);
+	// init templates
+	templatesInit(this);
 
-  // init blocks
-  blocksInit(this);
+	// init blocks
+	blocksInit(this);
 
 };
 

--- a/lib/dialects/mssql/index.js
+++ b/lib/dialects/mssql/index.js
@@ -3,97 +3,47 @@
 var BaseDialect = require('../base');
 var _ = require('underscore');
 var util = require('util');
+var templatesInit = require('./templates');
+var blocksInit = require('./blocks');
 var templateChecks = require('../../utils/templateChecks');
 
 var Dialect = module.exports = function(builder) {
-	builder.options.valuesPrefix = '@';
-	
-	builder._pushValue = function(value) {
-		if (_.isUndefined(value) || _.isNull(value)) {
-			return 'null';
-		} else if (_.isBoolean(value)) {
-			return String(Number(value));
-		} else if (_.isNumber(value)) {
-			return String(value);
-		} else if (_.isString(value) || _.isDate(value)) {
-			if (this.options.separatedValues) {
-				var placeholder = this._getPlaceholder();
 
-				if (this.options.namedValues) {
-					this._values[placeholder] = value;
-				} else {
-					this._values.push(value);
-				}
+  builder._pushValue = function(value) {
+    if (_.isUndefined(value) || _.isNull(value)) {
+      return 'null';
+    } else if (_.isBoolean(value)) {
+      return String(Number(value));
+    } else if (_.isNumber(value)) {
+      return String(value);
+    } else if (_.isString(value) || _.isDate(value)) {
+      if (this.options.separatedValues) {
+        var placeholder = this._getPlaceholder();
 
-				return this._wrapPlaceholder(placeholder);
-			} else {
-				if (_.isDate(value)) value = value.toISOString();
+        if (this.options.namedValues) {
+          this._values[placeholder] = value;
+        } else {
+          this._values.push(value);
+        }
 
-				return '\'' + value + '\'';
-			}
-		} else {
-			throw new Error('Wrong value type "' + (typeof value) + '"');
-		}
-	};
-	
-	BaseDialect.call(this, builder);
+        return this._wrapPlaceholder(placeholder);
+      } else {
+        if (_.isDate(value)) value = value.toISOString();
 
-	this.blocks.set('limit', function(params) {
-		return (!isNaN(params.offset)) ? '' : 'TOP(' + builder._pushValue(params.limit) + ')';
-	});
+        return '\'' + value + '\'';
+      }
+    } else {
+      throw new Error('Wrong value type "' + (typeof value) + '"');
+    }
+  };
 
-	this.blocks.set('offset', function(params) {
-		var pre = (!params.sort) ? 'ORDER BY 1 ' : '';
-		if (params.limit) {
-			var str = pre + 'OFFSET ' + builder._pushValue(params.offset);
-			str += ' ROWS FETCH NEXT ' + builder._pushValue(params.limit) + ' ROWS ONLY';
-			return str;
-		}else {
-			return pre + 'OFFSET ' + builder._pushValue(params.offset) + ' ROWS';
-		}
-	});
+  BaseDialect.call(this, builder);
 
-	this.templates.set('select', {
-		pattern: '{with} {withRecursive} select {limit} {distinct} {fields} ' +
-			'from {from} {table} {query} {select} {expression} {alias} ' +
-			'{join} {condition} {group} {having} {sort} {offset}',
-		defaults: {
-			fields: {}
-		},
-		validate: function(type, params) {
-			templateChecks.onlyOneOfProps(type, params, ['with', 'withRecursive']);
-			templateChecks.propType(type, params, 'with', 'object');
-			templateChecks.propType(type, params, 'withRecursive', 'object');
+  // init templates
+  templatesInit(this);
 
-			templateChecks.propType(type, params, 'distinct', 'boolean');
-
-			templateChecks.propType(type, params, 'fields', ['array', 'object']);
-
-			templateChecks.propType(type, params, 'from', ['string', 'array', 'object']);
-
-			templateChecks.atLeastOneOfProps(type, params, ['table', 'query', 'select', 'expression']);
-			templateChecks.onlyOneOfProps(type, params, ['table', 'query', 'select', 'expression']);
-
-			templateChecks.propType(type, params, 'table', 'string');
-			templateChecks.propType(type, params, 'query', 'object');
-			templateChecks.propType(type, params, 'select', 'object');
-			templateChecks.propType(type, params, 'expression', ['string', 'object']);
-
-			templateChecks.propType(type, params, 'alias', ['string', 'object']);
-
-			templateChecks.propType(type, params, 'join', ['array', 'object']);
-
-			templateChecks.propType(type, params, 'condition', ['array', 'object']);
-			templateChecks.propType(type, params, 'having', ['array', 'object']);
-
-			templateChecks.propType(type, params, 'group', ['string', 'array']);
-
-			templateChecks.propType(type, params, 'sort', ['string', 'array', 'object']);
-
-			templateChecks.propType(type, params, 'offset', ['number', 'string']);
-			templateChecks.propType(type, params, 'limit', ['number', 'string']);
-		}
-	});
+  // init blocks
+  blocksInit(this);
 
 };
 

--- a/lib/dialects/mssql/index.js
+++ b/lib/dialects/mssql/index.js
@@ -7,35 +7,6 @@ var templatesInit = require('./templates');
 var blocksInit = require('./blocks');
 
 var Dialect = module.exports = function(builder) {
-
-	builder._pushValue = function(value) {
-		if (_.isUndefined(value) || _.isNull(value)) {
-			return 'null';
-		} else if (_.isBoolean(value)) {
-			return String(Number(value));
-		} else if (_.isNumber(value)) {
-			return String(value);
-		} else if (_.isString(value) || _.isDate(value)) {
-			if (this.options.separatedValues) {
-				var placeholder = this._getPlaceholder();
-
-				if (this.options.namedValues) {
-					this._values[placeholder] = value;
-				} else {
-					this._values.push(value);
-				}
-
-				return this._wrapPlaceholder(placeholder);
-			} else {
-				if (_.isDate(value)) value = value.toISOString();
-
-				return '\'' + value + '\'';
-			}
-		} else {
-			throw new Error('Wrong value type "' + (typeof value) + '"');
-		}
-	};
-
 	BaseDialect.call(this, builder);
 
 	// init templates
@@ -43,9 +14,11 @@ var Dialect = module.exports = function(builder) {
 
 	// init blocks
 	blocksInit(this);
-
 };
 
 util.inherits(Dialect, BaseDialect);
 
-Dialect.prototype.config = _({}).extend(BaseDialect.prototype.config, {});
+Dialect.prototype.config = _({}).extend(BaseDialect.prototype.config, {
+	identifierPrefix: '[',
+	identifierSuffix: ']'
+});

--- a/lib/dialects/mssql/index.js
+++ b/lib/dialects/mssql/index.js
@@ -7,6 +7,35 @@ var templateChecks = require('../../utils/templateChecks');
 
 var Dialect = module.exports = function(builder) {
 	builder.options.valuesPrefix = '@';
+	
+	builder._pushValue = function(value) {
+		if (_.isUndefined(value) || _.isNull(value)) {
+			return 'null';
+		} else if (_.isBoolean(value)) {
+			return String(Number(value));
+		} else if (_.isNumber(value)) {
+			return String(value);
+		} else if (_.isString(value) || _.isDate(value)) {
+			if (this.options.separatedValues) {
+				var placeholder = this._getPlaceholder();
+
+				if (this.options.namedValues) {
+					this._values[placeholder] = value;
+				} else {
+					this._values.push(value);
+				}
+
+				return this._wrapPlaceholder(placeholder);
+			} else {
+				if (_.isDate(value)) value = value.toISOString();
+
+				return '\'' + value + '\'';
+			}
+		} else {
+			throw new Error('Wrong value type "' + (typeof value) + '"');
+		}
+	};
+	
 	BaseDialect.call(this, builder);
 
 	this.blocks.set('limit', function(params) {

--- a/lib/dialects/mssql/index.js
+++ b/lib/dialects/mssql/index.js
@@ -3,9 +3,66 @@
 var BaseDialect = require('../base');
 var _ = require('underscore');
 var util = require('util');
+var templateChecks = require('../../utils/templateChecks');
 
 var Dialect = module.exports = function(builder) {
 	BaseDialect.call(this, builder);
+
+  this.blocks.set('limit', function(params) {
+		return (params.offset) ? '' : 'TOP(' + builder._pushValue(params.limit) + ')';
+	});
+
+  this.blocks.set('offset', function(params) {
+    var pre = (!params.sort) ? 'ORDER BY 1 ' : '';
+    if (params.limit) {
+      return pre + 'OFFSET ' + params.offset + ' ROWS FETCH NEXT ' + params.limit + ' ROWS ONLY';
+    }else {
+      return pre + 'OFFSET ' + params.offset + ' ROWS';
+    }
+	});
+
+  this.templates.set('select', {
+		pattern: '{with} {withRecursive} select {limit} {distinct} {fields} ' +
+			'from {from} {table} {query} {select} {expression} {alias} ' +
+			'{join} {condition} {group} {having} {sort} {offset}',
+		defaults: {
+			fields: {}
+		},
+		validate: function(type, params) {
+			templateChecks.onlyOneOfProps(type, params, ['with', 'withRecursive']);
+			templateChecks.propType(type, params, 'with', 'object');
+			templateChecks.propType(type, params, 'withRecursive', 'object');
+
+			templateChecks.propType(type, params, 'distinct', 'boolean');
+
+			templateChecks.propType(type, params, 'fields', ['array', 'object']);
+
+			templateChecks.propType(type, params, 'from', ['string', 'array', 'object']);
+
+			templateChecks.atLeastOneOfProps(type, params, ['table', 'query', 'select', 'expression']);
+			templateChecks.onlyOneOfProps(type, params, ['table', 'query', 'select', 'expression']);
+
+			templateChecks.propType(type, params, 'table', 'string');
+			templateChecks.propType(type, params, 'query', 'object');
+			templateChecks.propType(type, params, 'select', 'object');
+			templateChecks.propType(type, params, 'expression', ['string', 'object']);
+
+			templateChecks.propType(type, params, 'alias', ['string', 'object']);
+
+			templateChecks.propType(type, params, 'join', ['array', 'object']);
+
+			templateChecks.propType(type, params, 'condition', ['array', 'object']);
+			templateChecks.propType(type, params, 'having', ['array', 'object']);
+
+			templateChecks.propType(type, params, 'group', ['string', 'array']);
+
+			templateChecks.propType(type, params, 'sort', ['string', 'array', 'object']);
+
+      templateChecks.propType(type, params, 'offset', ['number', 'string']);
+			templateChecks.propType(type, params, 'limit', ['number', 'string']);
+		}
+	});
+
 };
 
 util.inherits(Dialect, BaseDialect);

--- a/lib/dialects/mssql/templates.js
+++ b/lib/dialects/mssql/templates.js
@@ -1,0 +1,131 @@
+'use strict';
+
+var _ = require('underscore');
+var templateChecks = require('../../utils/templateChecks');
+var orRegExp = /^(rollback|abort|replace|fail|ignore)$/i;
+
+module.exports = function(dialect) {
+  dialect.templates.set('select', {
+    pattern: '{with} {withRecursive} select {limit} {distinct} {fields} ' +
+     'from {from} {table} {query} {select} {expression} {alias} ' +
+     '{join} {condition} {group} {having} {sort} {offset}',
+    defaults: {
+      fields: {}
+    },
+    validate: function(type, params) {
+      templateChecks.onlyOneOfProps(type, params, ['with', 'withRecursive']);
+      templateChecks.propType(type, params, 'with', 'object');
+      templateChecks.propType(type, params, 'withRecursive', 'object');
+
+      templateChecks.propType(type, params, 'distinct', 'boolean');
+
+      templateChecks.propType(type, params, 'fields', ['array', 'object']);
+
+      templateChecks.propType(type, params, 'from', ['string', 'array', 'object']);
+
+      templateChecks.atLeastOneOfProps(type, params, ['table', 'query', 'select', 'expression']);
+      templateChecks.onlyOneOfProps(type, params, ['table', 'query', 'select', 'expression']);
+
+      templateChecks.propType(type, params, 'table', 'string');
+      templateChecks.propType(type, params, 'query', 'object');
+      templateChecks.propType(type, params, 'select', 'object');
+      templateChecks.propType(type, params, 'expression', ['string', 'object']);
+
+      templateChecks.propType(type, params, 'alias', ['string', 'object']);
+
+      templateChecks.propType(type, params, 'join', ['array', 'object']);
+
+      templateChecks.propType(type, params, 'condition', ['array', 'object']);
+      templateChecks.propType(type, params, 'having', ['array', 'object']);
+
+      templateChecks.propType(type, params, 'group', ['string', 'array']);
+
+      templateChecks.propType(type, params, 'sort', ['string', 'array', 'object']);
+
+      templateChecks.propType(type, params, 'offset', ['number', 'string']);
+      templateChecks.propType(type, params, 'limit', ['number', 'string']);
+    }
+  });
+
+
+  dialect.templates.add('insert', {
+		pattern: '{with} {withRecursive} insert {or} into {table} {values} ' +
+			'{condition}',
+		validate: function(type, params) {
+			templateChecks.onlyOneOfProps(type, params, ['with', 'withRecursive']);
+			templateChecks.propType(type, params, 'with', 'object');
+			templateChecks.propType(type, params, 'withRecursive', 'object');
+
+			templateChecks.propType(type, params, 'or', 'string');
+			templateChecks.propMatch(type, params, 'or', orRegExp);
+
+			templateChecks.requiredProp(type, params, 'table');
+			templateChecks.propType(type, params, 'table', 'string');
+
+			templateChecks.requiredProp(type, params, 'values');
+			templateChecks.propType(type, params, 'values', ['array', 'object']);
+
+			templateChecks.propType(type, params, 'condition', ['array', 'object']);
+
+		}
+	});
+
+  dialect.templates.add('insertValues', {
+    pattern: '({fields}) {returning} values {values}',
+    validate: function(type, params) {
+      templateChecks.requiredProp('values', params, 'fields');
+      templateChecks.propType('values', params, 'fields', 'array');
+      templateChecks.minPropLength('values', params, 'fields', 1);
+
+      templateChecks.propType(type, params, 'returning', ['array', 'object']);
+
+      templateChecks.requiredProp('values', params, 'values');
+      templateChecks.propType('values', params, 'values', 'array');
+      templateChecks.minPropLength('values', params, 'values', 1);
+    }
+  });
+
+	dialect.templates.add('update', {
+		pattern: '{with} {withRecursive} update {or} {table} {alias} {modifier} {returning} {condition} ',
+		validate: function(type, params) {
+			templateChecks.onlyOneOfProps(type, params, ['with', 'withRecursive']);
+			templateChecks.propType(type, params, 'with', 'object');
+			templateChecks.propType(type, params, 'withRecursive', 'object');
+
+			templateChecks.propType(type, params, 'or', 'string');
+			templateChecks.propMatch(type, params, 'or', orRegExp);
+
+			templateChecks.requiredProp(type, params, 'table');
+			templateChecks.propType(type, params, 'table', 'string');
+
+      templateChecks.propType(type, params, 'returning', ['array', 'object']);
+
+			templateChecks.propType(type, params, 'alias', 'string');
+
+			templateChecks.requiredProp(type, params, 'modifier');
+			templateChecks.propType(type, params, 'modifier', 'object');
+
+			templateChecks.propType(type, params, 'condition', ['array', 'object']);
+
+		}
+	});
+
+	dialect.templates.add('remove', {
+		pattern: '{with} {withRecursive} delete from {table} {returning} {alias} {condition} ',
+		validate: function(type, params) {
+			templateChecks.onlyOneOfProps(type, params, ['with', 'withRecursive']);
+			templateChecks.propType(type, params, 'with', 'object');
+			templateChecks.propType(type, params, 'withRecursive', 'object');
+
+			templateChecks.requiredProp(type, params, 'table');
+			templateChecks.propType(type, params, 'table', 'string');
+
+      templateChecks.propType(type, params, 'returning', ['array', 'object']);
+
+			templateChecks.propType(type, params, 'alias', 'string');
+
+			templateChecks.propType(type, params, 'condition', ['array', 'object']);
+
+		}
+	});
+};

--- a/lib/dialects/mssql/templates.js
+++ b/lib/dialects/mssql/templates.js
@@ -1,130 +1,130 @@
 'use strict';
 
-var _ = require('underscore');
 var templateChecks = require('../../utils/templateChecks');
 var orRegExp = /^(rollback|abort|replace|fail|ignore)$/i;
 
 module.exports = function(dialect) {
-  dialect.templates.set('select', {
-    pattern: '{with} {withRecursive} select {limit} {distinct} {fields} ' +
-     'from {from} {table} {query} {select} {expression} {alias} ' +
-     '{join} {condition} {group} {having} {sort} {offset}',
-    defaults: {
-      fields: {}
-    },
-    validate: function(type, params) {
-      templateChecks.onlyOneOfProps(type, params, ['with', 'withRecursive']);
-      templateChecks.propType(type, params, 'with', 'object');
-      templateChecks.propType(type, params, 'withRecursive', 'object');
+	dialect.templates.set('select', {
+		pattern: '{with} {withRecursive} select {limit} {distinct} {fields} ' +
+		 'from {from} {table} {query} {select} {expression} {alias} ' +
+		 '{join} {condition} {group} {having} {sort} {offset}',
+		defaults: {
+			fields: {}
+		},
+		validate: function(type, params) {
+			templateChecks.onlyOneOfProps(type, params, ['with', 'withRecursive']);
+			templateChecks.propType(type, params, 'with', 'object');
+			templateChecks.propType(type, params, 'withRecursive', 'object');
 
-      templateChecks.propType(type, params, 'distinct', 'boolean');
+			templateChecks.propType(type, params, 'distinct', 'boolean');
 
-      templateChecks.propType(type, params, 'fields', ['array', 'object']);
+			templateChecks.propType(type, params, 'fields', ['array', 'object']);
 
-      templateChecks.propType(type, params, 'from', ['string', 'array', 'object']);
+			templateChecks.propType(type, params, 'from', ['string', 'array', 'object']);
 
-      templateChecks.atLeastOneOfProps(type, params, ['table', 'query', 'select', 'expression']);
-      templateChecks.onlyOneOfProps(type, params, ['table', 'query', 'select', 'expression']);
+			templateChecks.atLeastOneOfProps(type, params, ['table', 'query', 'select', 'expression']);
+			templateChecks.onlyOneOfProps(type, params, ['table', 'query', 'select', 'expression']);
 
-      templateChecks.propType(type, params, 'table', 'string');
-      templateChecks.propType(type, params, 'query', 'object');
-      templateChecks.propType(type, params, 'select', 'object');
-      templateChecks.propType(type, params, 'expression', ['string', 'object']);
+			templateChecks.propType(type, params, 'table', 'string');
+			templateChecks.propType(type, params, 'query', 'object');
+			templateChecks.propType(type, params, 'select', 'object');
+			templateChecks.propType(type, params, 'expression', ['string', 'object']);
 
-      templateChecks.propType(type, params, 'alias', ['string', 'object']);
+			templateChecks.propType(type, params, 'alias', ['string', 'object']);
 
-      templateChecks.propType(type, params, 'join', ['array', 'object']);
+			templateChecks.propType(type, params, 'join', ['array', 'object']);
 
-      templateChecks.propType(type, params, 'condition', ['array', 'object']);
-      templateChecks.propType(type, params, 'having', ['array', 'object']);
+			templateChecks.propType(type, params, 'condition', ['array', 'object']);
+			templateChecks.propType(type, params, 'having', ['array', 'object']);
 
-      templateChecks.propType(type, params, 'group', ['string', 'array']);
+			templateChecks.propType(type, params, 'group', ['string', 'array']);
 
-      templateChecks.propType(type, params, 'sort', ['string', 'array', 'object']);
+			templateChecks.propType(type, params, 'sort', ['string', 'array', 'object']);
 
-      templateChecks.propType(type, params, 'offset', ['number', 'string']);
-      templateChecks.propType(type, params, 'limit', ['number', 'string']);
-    }
-  });
+			templateChecks.propType(type, params, 'offset', ['number', 'string']);
+			templateChecks.propType(type, params, 'limit', ['number', 'string']);
+		}
+	});
 
-  dialect.templates.add('insert', {
-    pattern: '{with} {withRecursive} insert {or} into {table} {values} ' +
-     '{condition}',
-    validate: function(type, params) {
-      templateChecks.onlyOneOfProps(type, params, ['with', 'withRecursive']);
-      templateChecks.propType(type, params, 'with', 'object');
-      templateChecks.propType(type, params, 'withRecursive', 'object');
+	dialect.templates.add('insert', {
+		pattern: '{with} {withRecursive} insert {or} into {table} {values} ' +
+		 '{condition}',
+		validate: function(type, params) {
+			templateChecks.onlyOneOfProps(type, params, ['with', 'withRecursive']);
+			templateChecks.propType(type, params, 'with', 'object');
+			templateChecks.propType(type, params, 'withRecursive', 'object');
 
-      templateChecks.propType(type, params, 'or', 'string');
-      templateChecks.propMatch(type, params, 'or', orRegExp);
+			templateChecks.propType(type, params, 'or', 'string');
+			templateChecks.propMatch(type, params, 'or', orRegExp);
 
-      templateChecks.requiredProp(type, params, 'table');
-      templateChecks.propType(type, params, 'table', 'string');
+			templateChecks.requiredProp(type, params, 'table');
+			templateChecks.propType(type, params, 'table', 'string');
 
-      templateChecks.requiredProp(type, params, 'values');
-      templateChecks.propType(type, params, 'values', ['array', 'object']);
+			templateChecks.requiredProp(type, params, 'values');
+			templateChecks.propType(type, params, 'values', ['array', 'object']);
 
-      templateChecks.propType(type, params, 'condition', ['array', 'object']);
+			templateChecks.propType(type, params, 'condition', ['array', 'object']);
 
-    }
-  });
+		}
+	});
 
-  dialect.templates.add('insertValues', {
-    pattern: '({fields}) {returning} values {values}',
-    validate: function(type, params) {
-      templateChecks.requiredProp('values', params, 'fields');
-      templateChecks.propType('values', params, 'fields', 'array');
-      templateChecks.minPropLength('values', params, 'fields', 1);
+	dialect.templates.add('insertValues', {
+		pattern: '({fields}) {returning} values {values}',
+		validate: function(type, params) {
+			templateChecks.requiredProp('values', params, 'fields');
+			templateChecks.propType('values', params, 'fields', 'array');
+			templateChecks.minPropLength('values', params, 'fields', 1);
 
-      templateChecks.propType(type, params, 'returning', ['array', 'object']);
+			templateChecks.propType(type, params, 'returning', ['array', 'object']);
 
-      templateChecks.requiredProp('values', params, 'values');
-      templateChecks.propType('values', params, 'values', 'array');
-      templateChecks.minPropLength('values', params, 'values', 1);
-    }
-  });
+			templateChecks.requiredProp('values', params, 'values');
+			templateChecks.propType('values', params, 'values', 'array');
+			templateChecks.minPropLength('values', params, 'values', 1);
+		}
+	});
 
-  dialect.templates.add('update', {
-    pattern: '{with} {withRecursive} update {or} {table} {alias} {modifier} {returning} {condition} ',
-    validate: function(type, params) {
-      templateChecks.onlyOneOfProps(type, params, ['with', 'withRecursive']);
-      templateChecks.propType(type, params, 'with', 'object');
-      templateChecks.propType(type, params, 'withRecursive', 'object');
+	dialect.templates.add('update', {
+		pattern: '{with} {withRecursive} update {or} {table} {alias} {modifier} {returning} ' +
+		 '{condition} ',
+		validate: function(type, params) {
+			templateChecks.onlyOneOfProps(type, params, ['with', 'withRecursive']);
+			templateChecks.propType(type, params, 'with', 'object');
+			templateChecks.propType(type, params, 'withRecursive', 'object');
 
-      templateChecks.propType(type, params, 'or', 'string');
-      templateChecks.propMatch(type, params, 'or', orRegExp);
+			templateChecks.propType(type, params, 'or', 'string');
+			templateChecks.propMatch(type, params, 'or', orRegExp);
 
-      templateChecks.requiredProp(type, params, 'table');
-      templateChecks.propType(type, params, 'table', 'string');
+			templateChecks.requiredProp(type, params, 'table');
+			templateChecks.propType(type, params, 'table', 'string');
 
-      templateChecks.propType(type, params, 'returning', ['array', 'object']);
+			templateChecks.propType(type, params, 'returning', ['array', 'object']);
 
-      templateChecks.propType(type, params, 'alias', 'string');
+			templateChecks.propType(type, params, 'alias', 'string');
 
-      templateChecks.requiredProp(type, params, 'modifier');
-      templateChecks.propType(type, params, 'modifier', 'object');
+			templateChecks.requiredProp(type, params, 'modifier');
+			templateChecks.propType(type, params, 'modifier', 'object');
 
-      templateChecks.propType(type, params, 'condition', ['array', 'object']);
+			templateChecks.propType(type, params, 'condition', ['array', 'object']);
 
-    }
-  });
+		}
+	});
 
-  dialect.templates.add('remove', {
-    pattern: '{with} {withRecursive} delete from {table} {returning} {alias} {condition} ',
-    validate: function(type, params) {
-      templateChecks.onlyOneOfProps(type, params, ['with', 'withRecursive']);
-      templateChecks.propType(type, params, 'with', 'object');
-      templateChecks.propType(type, params, 'withRecursive', 'object');
+	dialect.templates.add('remove', {
+		pattern: '{with} {withRecursive} delete from {table} {returning} {alias} {condition} ',
+		validate: function(type, params) {
+			templateChecks.onlyOneOfProps(type, params, ['with', 'withRecursive']);
+			templateChecks.propType(type, params, 'with', 'object');
+			templateChecks.propType(type, params, 'withRecursive', 'object');
 
-      templateChecks.requiredProp(type, params, 'table');
-      templateChecks.propType(type, params, 'table', 'string');
+			templateChecks.requiredProp(type, params, 'table');
+			templateChecks.propType(type, params, 'table', 'string');
 
-      templateChecks.propType(type, params, 'returning', ['array', 'object']);
+			templateChecks.propType(type, params, 'returning', ['array', 'object']);
 
-      templateChecks.propType(type, params, 'alias', 'string');
+			templateChecks.propType(type, params, 'alias', 'string');
 
-      templateChecks.propType(type, params, 'condition', ['array', 'object']);
+			templateChecks.propType(type, params, 'condition', ['array', 'object']);
 
-    }
-  });
+		}
+	});
 };

--- a/lib/dialects/mssql/templates.js
+++ b/lib/dialects/mssql/templates.js
@@ -47,28 +47,27 @@ module.exports = function(dialect) {
     }
   });
 
-
   dialect.templates.add('insert', {
-		pattern: '{with} {withRecursive} insert {or} into {table} {values} ' +
-			'{condition}',
-		validate: function(type, params) {
-			templateChecks.onlyOneOfProps(type, params, ['with', 'withRecursive']);
-			templateChecks.propType(type, params, 'with', 'object');
-			templateChecks.propType(type, params, 'withRecursive', 'object');
+    pattern: '{with} {withRecursive} insert {or} into {table} {values} ' +
+     '{condition}',
+    validate: function(type, params) {
+      templateChecks.onlyOneOfProps(type, params, ['with', 'withRecursive']);
+      templateChecks.propType(type, params, 'with', 'object');
+      templateChecks.propType(type, params, 'withRecursive', 'object');
 
-			templateChecks.propType(type, params, 'or', 'string');
-			templateChecks.propMatch(type, params, 'or', orRegExp);
+      templateChecks.propType(type, params, 'or', 'string');
+      templateChecks.propMatch(type, params, 'or', orRegExp);
 
-			templateChecks.requiredProp(type, params, 'table');
-			templateChecks.propType(type, params, 'table', 'string');
+      templateChecks.requiredProp(type, params, 'table');
+      templateChecks.propType(type, params, 'table', 'string');
 
-			templateChecks.requiredProp(type, params, 'values');
-			templateChecks.propType(type, params, 'values', ['array', 'object']);
+      templateChecks.requiredProp(type, params, 'values');
+      templateChecks.propType(type, params, 'values', ['array', 'object']);
 
-			templateChecks.propType(type, params, 'condition', ['array', 'object']);
+      templateChecks.propType(type, params, 'condition', ['array', 'object']);
 
-		}
-	});
+    }
+  });
 
   dialect.templates.add('insertValues', {
     pattern: '({fields}) {returning} values {values}',
@@ -85,47 +84,47 @@ module.exports = function(dialect) {
     }
   });
 
-	dialect.templates.add('update', {
-		pattern: '{with} {withRecursive} update {or} {table} {alias} {modifier} {returning} {condition} ',
-		validate: function(type, params) {
-			templateChecks.onlyOneOfProps(type, params, ['with', 'withRecursive']);
-			templateChecks.propType(type, params, 'with', 'object');
-			templateChecks.propType(type, params, 'withRecursive', 'object');
+  dialect.templates.add('update', {
+    pattern: '{with} {withRecursive} update {or} {table} {alias} {modifier} {returning} {condition} ',
+    validate: function(type, params) {
+      templateChecks.onlyOneOfProps(type, params, ['with', 'withRecursive']);
+      templateChecks.propType(type, params, 'with', 'object');
+      templateChecks.propType(type, params, 'withRecursive', 'object');
 
-			templateChecks.propType(type, params, 'or', 'string');
-			templateChecks.propMatch(type, params, 'or', orRegExp);
+      templateChecks.propType(type, params, 'or', 'string');
+      templateChecks.propMatch(type, params, 'or', orRegExp);
 
-			templateChecks.requiredProp(type, params, 'table');
-			templateChecks.propType(type, params, 'table', 'string');
-
-      templateChecks.propType(type, params, 'returning', ['array', 'object']);
-
-			templateChecks.propType(type, params, 'alias', 'string');
-
-			templateChecks.requiredProp(type, params, 'modifier');
-			templateChecks.propType(type, params, 'modifier', 'object');
-
-			templateChecks.propType(type, params, 'condition', ['array', 'object']);
-
-		}
-	});
-
-	dialect.templates.add('remove', {
-		pattern: '{with} {withRecursive} delete from {table} {returning} {alias} {condition} ',
-		validate: function(type, params) {
-			templateChecks.onlyOneOfProps(type, params, ['with', 'withRecursive']);
-			templateChecks.propType(type, params, 'with', 'object');
-			templateChecks.propType(type, params, 'withRecursive', 'object');
-
-			templateChecks.requiredProp(type, params, 'table');
-			templateChecks.propType(type, params, 'table', 'string');
+      templateChecks.requiredProp(type, params, 'table');
+      templateChecks.propType(type, params, 'table', 'string');
 
       templateChecks.propType(type, params, 'returning', ['array', 'object']);
 
-			templateChecks.propType(type, params, 'alias', 'string');
+      templateChecks.propType(type, params, 'alias', 'string');
 
-			templateChecks.propType(type, params, 'condition', ['array', 'object']);
+      templateChecks.requiredProp(type, params, 'modifier');
+      templateChecks.propType(type, params, 'modifier', 'object');
 
-		}
-	});
+      templateChecks.propType(type, params, 'condition', ['array', 'object']);
+
+    }
+  });
+
+  dialect.templates.add('remove', {
+    pattern: '{with} {withRecursive} delete from {table} {returning} {alias} {condition} ',
+    validate: function(type, params) {
+      templateChecks.onlyOneOfProps(type, params, ['with', 'withRecursive']);
+      templateChecks.propType(type, params, 'with', 'object');
+      templateChecks.propType(type, params, 'withRecursive', 'object');
+
+      templateChecks.requiredProp(type, params, 'table');
+      templateChecks.propType(type, params, 'table', 'string');
+
+      templateChecks.propType(type, params, 'returning', ['array', 'object']);
+
+      templateChecks.propType(type, params, 'alias', 'string');
+
+      templateChecks.propType(type, params, 'condition', ['array', 'object']);
+
+    }
+  });
 };

--- a/lib/dialects/mssql/templates.js
+++ b/lib/dialects/mssql/templates.js
@@ -46,9 +46,9 @@ module.exports = function(dialect) {
 		}
 	});
 
-	dialect.templates.add('insert', {
+	dialect.templates.set('insert', {
 		pattern: '{with} {withRecursive} insert {or} into {table} {values} ' +
-		 '{condition}',
+			'{condition}',
 		validate: function(type, params) {
 			templateChecks.onlyOneOfProps(type, params, ['with', 'withRecursive']);
 			templateChecks.propType(type, params, 'with', 'object');
@@ -68,7 +68,7 @@ module.exports = function(dialect) {
 		}
 	});
 
-	dialect.templates.add('insertValues', {
+	dialect.templates.set('insertValues', {
 		pattern: '({fields}) {returning} values {values}',
 		validate: function(type, params) {
 			templateChecks.requiredProp('values', params, 'fields');
@@ -83,7 +83,7 @@ module.exports = function(dialect) {
 		}
 	});
 
-	dialect.templates.add('update', {
+	dialect.templates.set('update', {
 		pattern: '{with} {withRecursive} update {or} {table} {alias} {modifier} {returning} ' +
 		 '{condition} ',
 		validate: function(type, params) {
@@ -109,7 +109,7 @@ module.exports = function(dialect) {
 		}
 	});
 
-	dialect.templates.add('remove', {
+	dialect.templates.set('remove', {
 		pattern: '{with} {withRecursive} delete from {table} {returning} {alias} {condition} ',
 		validate: function(type, params) {
 			templateChecks.onlyOneOfProps(type, params, ['with', 'withRecursive']);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "database"
   ],
   "dependencies": {
-    "underscore": "1.8.3"
+    "underscore": "1.8.2"
   },
   "devDependencies": {
     "chai": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "database"
   ],
   "dependencies": {
-    "underscore": "1.8.2"
+    "underscore": "1.8.3"
   },
   "devDependencies": {
     "chai": "2.2.0",

--- a/tests/6_dialects/1_mssql.js
+++ b/tests/6_dialects/1_mssql.js
@@ -1,60 +1,63 @@
 'use strict';
 
 var jsonSql = require('../../lib')({
-  dialect: 'mssql',
-  namedValues: false
+	dialect: 'mssql',
+	namedValues: false
 });
 var expect = require('chai').expect;
 
 describe('MSSQL dialect', function() {
-  describe('limit', function() {
-    it('should be ok with `limit` property', function() {
-      var result = jsonSql.build({
-        table: 'test',
-        fields: ['user'],
-        limit: 1,
-        condition: {
-          'name': {$eq: 'test'}
-        }
-      });
-      expect(result.query).to.be.equal('select top(1) "user" from "test" where "name" = $1;');
-    });
+	describe('limit', function() {
+		it('should be ok with `limit` property', function() {
+			var result = jsonSql.build({
+				table: 'test',
+				fields: ['user'],
+				limit: 1,
+				condition: {
+					'name': {$eq: 'test'}
+				}
+			});
+			expect(result.query).to.be.equal('select top(1) "user" from "test" where "name" = $1;');
+		});
 
-    it('should be ok with `limit` and `offset` properties', function() {
-      var result = jsonSql.build({
-        table: 'test',
-        fields: ['user'],
-        limit: 4,
-        offset: 2,
-        condition: {
-          'name': {$eq: 'test'}
-        }
-      });
-      expect(result.query).to.be.equal('select  "user" from "test" where "name" = $1 order by 1 offset 2 rows fetch next 4 rows only;');
-    });
-  });
-  describe('returning', function() {
-    it('should be ok with `remove` type', function() {
-      var result = jsonSql.build({
-        type: 'remove',
-        table: 'test',
-        returning: ['DELETED.*'],
-        condition: {
-          Description: {$eq: 'test'}
-        }
-      });
-      expect(result.query).to.be.equal('delete from "test" output "DELETED".* where "Description" = $1;');
-    });
-    it('should be ok with `insert` type', function() {
-      var result = jsonSql.build({
-        type: 'insert',
-        table: 'test',
-        returning: ['INSERTED.*'],
-        values: {
-          Description: 'test',
-        }
-      });
-      expect(result.query).to.be.equal('insert into "test" ("Description") output "INSERTED".* values ($1);');
-    });
-  });
+		it('should be ok with `limit` and `offset` properties', function() {
+			var result = jsonSql.build({
+				table: 'test',
+				fields: ['user'],
+				limit: 4,
+				offset: 2,
+				condition: {
+					'name': {$eq: 'test'}
+				}
+			});
+			expect(result.query).to.be.equal('select  "user" from "test" where "name" = $1 order by 1' +
+			 ' offset 2 rows fetch next 4 rows only;');
+		});
+	});
+	describe('returning', function() {
+		it('should be ok with `remove` type', function() {
+			var result = jsonSql.build({
+				type: 'remove',
+				table: 'test',
+				returning: ['DELETED.*'],
+				condition: {
+					Description: {$eq: 'test'}
+				}
+			});
+			expect(result.query).to.be.equal('delete from "test" output "DELETED".* where ' +
+			 '"Description" = $1;');
+		});
+		it('should be ok with `insert` type', function() {
+			var result = jsonSql.build({
+				type: 'insert',
+				table: 'test',
+				returning: ['INSERTED.*'],
+				values: {
+					Description: 'test',
+				}
+			});
+			expect(result.query).to.be.equal('insert into "test" ("Description") output ' +
+			 '"INSERTED".* values ($1);');
+		});
+	});
 });

--- a/tests/6_dialects/1_mssql.js
+++ b/tests/6_dialects/1_mssql.js
@@ -7,61 +7,238 @@ var jsonSql = require('../../lib')({
 var expect = require('chai').expect;
 
 describe('MSSQL dialect', function() {
-	describe('limit', function() {
+	describe('limit / offset', function() {
 		it('should be ok with `limit` property', function() {
 			var result = jsonSql.build({
-				table: 'test',
-				fields: ['user'],
+				table: 'users',
+				fields: ['id', 'name'],
 				limit: 1,
 				condition: {
-					'name': {$eq: 'test'}
+					'active': {$eq: '1'}
 				}
 			});
-			expect(result.query).to.be.equal('select top(1) [user] from [test] where [name] = $1;');
+			expect(result.query).to.be.equal(
+				'select top(1) [id], [name] from [users] where [active] = $1;'
+			);
+		});
+
+		it('should be ok with `limit` and `sort` properties', function() {
+			var result = jsonSql.build({
+				table: 'users',
+				fields: ['id', 'name'],
+				limit: 1,
+				sort: {
+					'lastLogin': -1
+				}
+			});
+			expect(result.query).to.be.equal(
+				'select top(1) [id], [name] from [users] order by [lastLogin] desc;'
+			);
+		});
+
+		it('should be ok with `offset` property', function() {
+			var result = jsonSql.build({
+				table: 'users',
+				fields: ['id', 'name'],
+				offset: 2,
+			});
+			expect(result.query).to.be.equal(
+				'select [id], [name] from [users] order by 1 offset 2 rows;'
+			);
+		});
+		it('should be ok with `offset` and `sort` properties', function() {
+			var result = jsonSql.build({
+				table: 'users',
+				fields: ['id', 'name'],
+				offset: 2,
+				sort: {
+					'lastLogin': -1
+				}
+			});
+			expect(result.query).to.be.equal(
+				'select [id], [name] from [users] order by [lastLogin] desc offset 2 rows;'
+			);
 		});
 
 		it('should be ok with `limit` and `offset` properties', function() {
 			var result = jsonSql.build({
-				table: 'test',
-				fields: ['user'],
+				table: 'users',
+				fields: ['id', 'name'],
+				limit: 4,
+				offset: 2
+			});
+			expect(result.query).to.be.equal(
+				'select [id], [name] from [users] order by 1 offset 2 rows fetch next 4 rows only;'
+			);
+		});
+
+		it('should be ok with `limit` and `offset` and `sort` properties', function() {
+			var result = jsonSql.build({
+				table: 'users',
+				fields: ['id', 'name'],
 				limit: 4,
 				offset: 2,
-				condition: {
-					'name': {$eq: 'test'}
+				sort: {
+					'lastLogin': -1
 				}
 			});
-			expect(result.query).to.be.equal('select [user] from [test] where [name] = $1 order by 1' +
-			 ' offset 2 rows fetch next 4 rows only;');
+			expect(result.query).to.be.equal(
+				'select [id], [name] from [users] order by [lastLogin] desc ' +
+				'offset 2 rows fetch next 4 rows only;'
+			);
 		});
 	});
-	describe('returning', function() {
-		it('should be ok with `remove` type', function() {
-			var result = jsonSql.build({
-				type: 'remove',
-				table: 'test',
-				returning: [
-					{table: 'deleted', name: '*'}
-				],
-				condition: {
-					Description: {$eq: 'test'}
-				}
-			});
-			expect(result.query).to.be.equal('delete from [test] output [deleted].* where ' +
-				'[Description] = $1;');
-		});
-		it('should be ok with `insert` type', function() {
+	describe('Insert', function() {
+		it('should be ok with different `values` property', function() {
+			var date = new Date();
 			var result = jsonSql.build({
 				type: 'insert',
-				table: 'test',
-				returning: [
-					{table: 'inserted', name: '*'}
-				],
+				table: 'users',
 				values: {
-					Description: 'test',
+					id: 1,
+					name: 'Max',
+					date: date,
+					lastLogin: null,
+					active: true
 				}
 			});
-			expect(result.query).to.be.equal('insert into [test] ([Description]) output ' +
-				'[inserted].* values ($1);');
+			expect(result.query).to.be.equal(
+				'insert into [users] ([id], [name], [date], [lastLogin], [active]) ' +
+				'values (1, $1, $2, null, 1);'
+			);
+		});
+
+		it('should be ok with different `values` property with option `separatedValues` = false',
+			function() {
+				var options = jsonSql.options;
+				jsonSql.configure({
+					dialect: 'mssql',
+					separatedValues: false
+				});
+				var date = new Date();
+				var result = jsonSql.build({
+					type: 'insert',
+					table: 'users',
+					values: {
+						id: 1,
+						name: 'Max',
+						date: date,
+						lastLogin: null,
+						active: true
+					}
+				});
+				expect(result.query).to.be.equal(
+					'insert into [users] ([id], [name], [date], [lastLogin], [active]) ' +
+					'values (1, \'Max\', \'' + date.toISOString() + '\', null, 1);'
+				);
+				jsonSql.configure(options);
+			}
+		);
+
+		it('should be ok with array `values` property', function() {
+			var result = jsonSql.build({
+				type: 'insert',
+				table: 'users',
+				values: [
+					{ id: 1, name: 'Max' },
+					{ id: 2, name: 'Jane' }
+				]
+			});
+			expect(result.query).to.be.equal('insert into [users] ([id], [name]) values (1, $1), (2, $2);');
+		});
+
+
+		it('should throw error with a null `returning` property', function() {
+			expect(function() {
+				jsonSql.build({
+					type: 'insert',
+					table: 'users',
+					values: {
+						name: 'Max'
+					},
+					returning: null
+				});
+			}).to.throw(
+				'`returning` property should have one of expected types: "array", "object" ' +
+				'in `insertValues` clause'
+			);
+		});
+
+		it('should be ok with `returning` property', function() {
+			var result = jsonSql.build({
+				type: 'insert',
+				table: 'users',
+				values: {
+					name: 'Max'
+				},
+				returning: [
+					{table: 'inserted', name: 'id'}
+				],
+			});
+			expect(result.query).to.be.equal(
+				'insert into [users] ([name]) output [inserted].[id] values ($1);'
+			);
+		});
+
+	});
+
+	describe('Update', function() {
+		it('should throw error with a null `returning` property', function() {
+			expect(function() {
+				jsonSql.build({
+					type: 'update',
+					table: 'users',
+					modifier: {
+						$dec: {
+							age: 3
+						}
+					},
+					returning: null
+				});
+			}).to.throw(
+				'`returning` property should have one of expected types: "array", "object" ' +
+				'in `update` clause'
+			);
+		});
+
+		it('should be ok with `returning` property', function() {
+			var result = jsonSql.build({
+				type: 'update',
+				table: 'users',
+				modifier: {
+					$dec: {
+						age: 3
+					}
+				},
+				returning: ['inserted.*', 'deleted.*']
+			});
+			expect(result.query).to.be.equal(
+				'update [users] set [age] = [age] - 3 output [inserted].*, [deleted].*;'
+			);
+		});
+	});
+
+	describe('Delete', function() {
+		it('should throw error with a null `returning` property', function() {
+			expect(function() {
+				jsonSql.build({
+					type: 'remove',
+					table: 'users',
+					returning: null
+				});
+			}).to.throw(
+				'`returning` property should have one of expected types: "array", "object" ' +
+				'in `remove` clause'
+			);
+		});
+
+		it('should be ok with `returning` property', function() {
+			var result = jsonSql.build({
+				type: 'remove',
+				table: 'users',
+				returning: ['deleted.*']
+			});
+			expect(result.query).to.be.equal('delete from [users] output [deleted].*;');
 		});
 	});
 });

--- a/tests/6_dialects/1_mssql.js
+++ b/tests/6_dialects/1_mssql.js
@@ -17,7 +17,7 @@ describe('MSSQL dialect', function() {
 					'name': {$eq: 'test'}
 				}
 			});
-			expect(result.query).to.be.equal('select top(1) "user" from "test" where "name" = $1;');
+			expect(result.query).to.be.equal('select top(1) [user] from [test] where [name] = $1;');
 		});
 
 		it('should be ok with `limit` and `offset` properties', function() {
@@ -30,7 +30,7 @@ describe('MSSQL dialect', function() {
 					'name': {$eq: 'test'}
 				}
 			});
-			expect(result.query).to.be.equal('select  "user" from "test" where "name" = $1 order by 1' +
+			expect(result.query).to.be.equal('select [user] from [test] where [name] = $1 order by 1' +
 			 ' offset 2 rows fetch next 4 rows only;');
 		});
 	});
@@ -39,25 +39,29 @@ describe('MSSQL dialect', function() {
 			var result = jsonSql.build({
 				type: 'remove',
 				table: 'test',
-				returning: ['DELETED.*'],
+				returning: [
+					{table: 'deleted', name: '*'}
+				],
 				condition: {
 					Description: {$eq: 'test'}
 				}
 			});
-			expect(result.query).to.be.equal('delete from "test" output "DELETED".* where ' +
-			 '"Description" = $1;');
+			expect(result.query).to.be.equal('delete from [test] output [deleted].* where ' +
+				'[Description] = $1;');
 		});
 		it('should be ok with `insert` type', function() {
 			var result = jsonSql.build({
 				type: 'insert',
 				table: 'test',
-				returning: ['INSERTED.*'],
+				returning: [
+					{table: 'inserted', name: '*'}
+				],
 				values: {
 					Description: 'test',
 				}
 			});
-			expect(result.query).to.be.equal('insert into "test" ("Description") output ' +
-			 '"INSERTED".* values ($1);');
+			expect(result.query).to.be.equal('insert into [test] ([Description]) output ' +
+				'[inserted].* values ($1);');
 		});
 	});
 });

--- a/tests/6_dialects/1_mssql.js
+++ b/tests/6_dialects/1_mssql.js
@@ -1,0 +1,60 @@
+'use strict';
+
+var jsonSql = require('../../lib')({
+	dialect: 'mssql',
+	namedValues: false
+});
+var expect = require('chai').expect;
+
+describe('MSSQL dialect', function() {
+	describe('limit', function() {
+		it('should be ok with `limit` property', function() {
+			var result = jsonSql.build({
+				table: 'test',
+				fields: ['user'],
+        limit: 1,
+				condition: {
+					'name': {$eq: 'test'}
+				}
+			});
+			expect(result.query).to.be.equal('select top(1) "user" from "test" where "name" = $1;');
+		});
+
+    it('should be ok with `limit` and `offset` properties', function() {
+			var result = jsonSql.build({
+				table: 'test',
+				fields: ['user'],
+        limit: 4,
+        offset: 2,
+				condition: {
+					'name': {$eq: 'test'}
+				}
+			});
+			expect(result.query).to.be.equal('select  "user" from "test" where "name" = $1 order by 1 offset 2 rows fetch next 4 rows only;');
+		});
+  });
+	describe('returning', function() {
+			it('should be ok with `remove` type', function() {
+				var result = jsonSql.build({
+					type: 'remove',
+					table: 'test',
+					returning: ['DELETED.*'],
+					condition: {
+						Description: {$eq: 'test'}
+					}
+				});
+				expect(result.query).to.be.equal('delete from "test" output "DELETED".* where "Description" = $1;');
+			});
+			it('should be ok with `insert` type', function() {
+				var result = jsonSql.build({
+						type: 'insert',
+						table: 'test',
+						returning: ['INSERTED.*'],
+						values: {
+						Description: 'test',
+					}
+				});
+				expect(result.query).to.be.equal('insert into "test" ("Description") output "INSERTED".* values ($1);');
+			});
+	});
+});

--- a/tests/6_dialects/1_mssql.js
+++ b/tests/6_dialects/1_mssql.js
@@ -1,60 +1,60 @@
 'use strict';
 
 var jsonSql = require('../../lib')({
-	dialect: 'mssql',
-	namedValues: false
+  dialect: 'mssql',
+  namedValues: false
 });
 var expect = require('chai').expect;
 
 describe('MSSQL dialect', function() {
-	describe('limit', function() {
-		it('should be ok with `limit` property', function() {
-			var result = jsonSql.build({
-				table: 'test',
-				fields: ['user'],
+  describe('limit', function() {
+    it('should be ok with `limit` property', function() {
+      var result = jsonSql.build({
+        table: 'test',
+        fields: ['user'],
         limit: 1,
-				condition: {
-					'name': {$eq: 'test'}
-				}
-			});
-			expect(result.query).to.be.equal('select top(1) "user" from "test" where "name" = $1;');
-		});
+        condition: {
+          'name': {$eq: 'test'}
+        }
+      });
+      expect(result.query).to.be.equal('select top(1) "user" from "test" where "name" = $1;');
+    });
 
     it('should be ok with `limit` and `offset` properties', function() {
-			var result = jsonSql.build({
-				table: 'test',
-				fields: ['user'],
+      var result = jsonSql.build({
+        table: 'test',
+        fields: ['user'],
         limit: 4,
         offset: 2,
-				condition: {
-					'name': {$eq: 'test'}
-				}
-			});
-			expect(result.query).to.be.equal('select  "user" from "test" where "name" = $1 order by 1 offset 2 rows fetch next 4 rows only;');
-		});
+        condition: {
+          'name': {$eq: 'test'}
+        }
+      });
+      expect(result.query).to.be.equal('select  "user" from "test" where "name" = $1 order by 1 offset 2 rows fetch next 4 rows only;');
+    });
   });
-	describe('returning', function() {
-			it('should be ok with `remove` type', function() {
-				var result = jsonSql.build({
-					type: 'remove',
-					table: 'test',
-					returning: ['DELETED.*'],
-					condition: {
-						Description: {$eq: 'test'}
-					}
-				});
-				expect(result.query).to.be.equal('delete from "test" output "DELETED".* where "Description" = $1;');
-			});
-			it('should be ok with `insert` type', function() {
-				var result = jsonSql.build({
-						type: 'insert',
-						table: 'test',
-						returning: ['INSERTED.*'],
-						values: {
-						Description: 'test',
-					}
-				});
-				expect(result.query).to.be.equal('insert into "test" ("Description") output "INSERTED".* values ($1);');
-			});
-	});
+  describe('returning', function() {
+    it('should be ok with `remove` type', function() {
+      var result = jsonSql.build({
+        type: 'remove',
+        table: 'test',
+        returning: ['DELETED.*'],
+        condition: {
+          Description: {$eq: 'test'}
+        }
+      });
+      expect(result.query).to.be.equal('delete from "test" output "DELETED".* where "Description" = $1;');
+    });
+    it('should be ok with `insert` type', function() {
+      var result = jsonSql.build({
+        type: 'insert',
+        table: 'test',
+        returning: ['INSERTED.*'],
+        values: {
+          Description: 'test',
+        }
+      });
+      expect(result.query).to.be.equal('insert into "test" ("Description") output "INSERTED".* values ($1);');
+    });
+  });
 });


### PR DESCRIPTION
### Refactor mssql dialect as per pull #26 feedback

This pull request is a continuation of #26. I used @iteufel's work, implemented the changes requested, and improved the test coverage.

- Include all test files in gulp lint tasks
- Move mssql `value` block override to `blocks.js`
- Update mssql `limit` block to use `_.isUndefined` 
- Clean up minor mssql sql letter case and format
- Set the `mssql` `identifier` `prefix` and `suffix`

There are two changes to the **`base`** dialect.

- Refactor the `base` `insert:values` `block` function to clean up the logic (match the `mssql` `inserted:values` `block` function)
- Update `buildTemplate` to include an edge case where a `buildBlock`    function does not return any values. This prevents unnecessary whitespace in the final query string.

These changes are not strictly necessary. The `mssql` `insert:values` `block` could use the same structure as the original `base` `block`, and unnecessary whitespace has no issues in terms of functionality, simply aesthetics.

---

I will set review this pull request to record, and address the feedback given on #26
Let me know if this pull request is appropriate, or if there is anything I can help clean up.

Thanks for this great library!


