### PR TITLE
Add postgresql10 json operators

### DIFF
--- a/lib/dialects/postgresql/index.js
+++ b/lib/dialects/postgresql/index.js
@@ -7,6 +7,7 @@ var	util = require('util');
 var templatesInit = require('./templates');
 var blocksInit = require('./blocks');
 var operatorsInit = require('./operators');
+var modifiersInit = require('./modifiers');
 
 var Dialect = module.exports = function(builder) {
 	BaseDialect.call(this, builder);
@@ -19,6 +20,9 @@ var Dialect = module.exports = function(builder) {
 
 	// init operators
 	operatorsInit(this);
+
+	// init modifiers
+	modifiersInit(this);
 };
 
 util.inherits(Dialect, BaseDialect);

--- a/lib/dialects/postgresql/modifiers.js
+++ b/lib/dialects/postgresql/modifiers.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = function(dialect) {
+	dialect.modifiers.add('$jsonConcatenate', function(field, value) {
+		return [field, '=', field, '||', value].join(' ');
+	});
+
+	dialect.modifiers.add('$jsonDelete', function(field, value) {
+		return [field, '=', field, '-', value].join(' ');
+	});
+
+	dialect.modifiers.add('$jsonDeleteByPath', function(field, value) {
+		return [field, '=', field, '#-', value].join(' ');
+	});
+};

--- a/tests/6_dialects/0_postgresql.js
+++ b/tests/6_dialects/0_postgresql.js
@@ -122,6 +122,51 @@ describe('PostgreSQL dialect', function() {
 			);
 			expect(result.values).to.be.eql(['hello%']);
 		});
+
+		it('should be ok with `$jsonConcatenate` modification operator', function() {
+			var result = jsonSql.build({
+				type: 'update',
+				table: 'test',
+				modifier: {
+					$jsonConcatenate: {
+						params: {c: 1}
+					}
+				}
+			});
+
+			expect(result.query).to.be.equal('update "test" set "params" = "params" || $1;');
+			expect(result.values).to.be.eql(['{"c":1}']);
+		});
+
+		it('should be ok with `$jsonDelete` modification operator', function() {
+			var result = jsonSql.build({
+				type: 'update',
+				table: 'test',
+				modifier: {
+					$jsonDelete: {
+						params: {c: 1}
+					}
+				}
+			});
+
+			expect(result.query).to.be.equal('update "test" set "params" = "params" - $1;');
+			expect(result.values).to.be.eql(['{"c":1}']);
+		});
+
+		it('should be ok with `$jsonDeleteByPath` modification operator', function() {
+			var result = jsonSql.build({
+				type: 'update',
+				table: 'test',
+				modifier: {
+					$jsonDeleteByPath: {
+						params: '{1,d}'
+					}
+				}
+			});
+
+			expect(result.query).to.be.equal('update "test" set "params" = "params" #- $1;');
+			expect(result.values).to.be.eql(['{1,d}']);
+		});
 	});
 
 	describe('explain', function() {


### PR DESCRIPTION
Add [new json](https://www.postgresql.org/docs/current/static/functions-json.html#FUNCTIONS-JSONB-OP-TABLE) modifiers to postgresql dialect:
- `$jsonConcatenate`
```json
{
  "$jsonConcatenate": {
    "field": {"c": 1}
  }
}
```
=>  `field = field || '{"c": 1}'`

- `$jsonDelete`
```json
{
  "$jsonDelete": {
    "field": "c"
  }
}
```
=>  `field = field - 'c'`

- `$jsonDeleteByPath`
```json
{
  "$jsonDeleteByPath": {
    "field": "{1,c}"
  }
}
```
=>  `field = field #- '{1,c}'`