### PR TITLE
Add alias to subquery

### DIFF
--- a/lib/dialects/base/blocks.js
+++ b/lib/dialects/base/blocks.js
@@ -368,7 +368,10 @@ module.exports = function(dialect) {
 	});
 
 	dialect.blocks.add('query', function(params) {
-		return dialect.buildTemplate('subQuery', {queryBody: params.query});
+		return dialect.buildTemplate('subQuery', {
+			queryBody: params.query,
+			alias: params.query.alias
+		});
 	});
 
 	dialect.blocks.add('select', function(params) {

--- a/lib/dialects/base/blocks.js
+++ b/lib/dialects/base/blocks.js
@@ -368,17 +368,25 @@ module.exports = function(dialect) {
 	});
 
 	dialect.blocks.add('query', function(params) {
-		return dialect.buildTemplate('subQuery', {
-			queryBody: params.query,
-			alias: params.query.alias
-		});
+		var templateParams = {
+			queryBody: params.query
+		};
+		if (params.query && params.query.type === 'union') {
+			templateParams.alias = params.query.alias;
+		}
+
+		return dialect.buildTemplate('subQuery', templateParams);
 	});
 
 	dialect.blocks.add('select', function(params) {
-		return dialect.buildTemplate('subQuery', {
-			queryBody: params.select,
-			alias: params.select.alias
-		});
+		var templateParams = {
+			queryBody: params.select
+		};
+		if (params.select && params.select.type === 'union') {
+			templateParams.alias = params.select.alias;
+		}
+
+		return dialect.buildTemplate('subQuery', templateParams);
 	});
 
 	dialect.blocks.add('queries', function(params) {

--- a/lib/dialects/base/blocks.js
+++ b/lib/dialects/base/blocks.js
@@ -372,7 +372,10 @@ module.exports = function(dialect) {
 	});
 
 	dialect.blocks.add('select', function(params) {
-		return dialect.buildTemplate('subQuery', {queryBody: params.select});
+		return dialect.buildTemplate('subQuery', {
+			queryBody: params.select,
+			alias: params.select.alias
+		});
 	});
 
 	dialect.blocks.add('queries', function(params) {

--- a/lib/dialects/base/templates.js
+++ b/lib/dialects/base/templates.js
@@ -19,10 +19,12 @@ module.exports = function(dialect) {
 
 
 	dialect.templates.add('subQuery', {
-		pattern: '({queryBody})',
+		pattern: '({queryBody}) {alias}',
 		validate: function(type, params) {
 			templateChecks.requiredProp(type, params, 'queryBody');
 			templateChecks.propType(type, params, 'queryBody', 'object');
+
+			templateChecks.propType(type, params, 'alias', ['string', 'object']);
 		}
 	});
 


### PR DESCRIPTION
Alias is needed in case when complex select subquery will be used for example in join.