### PR TITLE
fix: bump underscore to >=1.12.1 for security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "database"
   ],
   "dependencies": {
-    "underscore": "1.8.2"
+    "underscore": ">=1.12.1"
   },
   "devDependencies": {
     "chai": "2.2.0",


### PR DESCRIPTION
@2do2go thanks for creating this package, could you please accept this PR so github stops the security vulnerability warning from underscore :)

cheers.